### PR TITLE
Add semantic test subs

### DIFF
--- a/lib/Cro/HTTP/Test.pm6
+++ b/lib/Cro/HTTP/Test.pm6
@@ -289,31 +289,31 @@ sub test-media-type(Cro::MediaType $got, Cro::MediaType $expected) {
     }
 }
 
-sub test-is-ok(|c) is hidden-from-backtrace is export {
+sub is-ok(|c) is hidden-from-backtrace is export {
     test |c, status => 200
 }
-sub test-is-no-content(|c) is hidden-from-backtrace is export {
+sub is-no-content(|c) is hidden-from-backtrace is export {
     test |c, status => 204
 }
-sub test-is-bad-request(|c) is hidden-from-backtrace is export {
+sub is-bad-request(|c) is hidden-from-backtrace is export {
     test |c, status => 400
 }
-sub test-is-unauthorized(|c) is hidden-from-backtrace is export {
+sub is-unauthorized(|c) is hidden-from-backtrace is export {
     test |c, status => 401
 }
-sub test-is-forbidden(|c) is hidden-from-backtrace is export {
+sub is-forbidden(|c) is hidden-from-backtrace is export {
     test |c, status => 403
 }
-sub test-is-not-found(|c) is hidden-from-backtrace is export {
+sub is-not-found(|c) is hidden-from-backtrace is export {
     test |c, status => 404
 }
-sub test-is-method-not-allowed(|c) is hidden-from-backtrace is export {
+sub is-method-not-allowed(|c) is hidden-from-backtrace is export {
     test |c, status => 405
 }
-sub test-is-conflict(|c) is hidden-from-backtrace is export {
+sub is-conflict(|c) is hidden-from-backtrace is export {
     test |c, status => 409
 }
-sub test-is-unprocessable-entity(|c) is hidden-from-backtrace is export {
+sub is-unprocessable-entity(|c) is hidden-from-backtrace is export {
     test |c, status => 422
 }
 

--- a/t/checks.t
+++ b/t/checks.t
@@ -41,7 +41,7 @@ test-service routes(), {
         status => 200,
         content-type => 'application/octet-stream',
         body-blob => * eq Blob.new(1,2,4,9);
-    test-is-ok get('/binary'),
+    is-ok get('/binary'),
         content-type => 'application/octet-stream',
         body-blob => *.elems == 4;
 

--- a/t/fake-auth.t
+++ b/t/fake-auth.t
@@ -30,7 +30,7 @@ test-service routes(), fake-auth => MySession.new, {
         status => 200;
     test get('/secret'),
         status => 401;
-    test-is-unauthorized get('/admin');
+    is-unauthorized get('/admin');
 
     test-given fake-auth => MySession.new(:logged-in), {
         test get('/public'),

--- a/t/http2.t
+++ b/t/http2.t
@@ -27,8 +27,8 @@ test-service routes(), :http<2>, {
             status => 200,
             json => { :result(42) };
 
-        test-is-bad-request post(json => { :x(37) });
+        is-bad-request post(json => { :x(37) });
 
-        test-is-method-not-allowed get(json => { :x(37) });
+        is-method-not-allowed get(json => { :x(37) });
     }
 }


### PR DESCRIPTION
As requested.  Lowercased.  Adapted one test for each status code to use the semantic version.  If you want all tests to use the semantic version, just let me know.