### PR TITLE
Move trait to candidates from proto

### DIFF
--- a/lib/Cro/HTTP/Test.pm6
+++ b/lib/Cro/HTTP/Test.pm6
@@ -125,11 +125,11 @@ multi post(*%client-options --> TestRequest) is export is test-assertion {
     request('POST', |%client-options)
 }
 
-proto put(|) is export is test-assertion { * }
-multi put(Str $path, *%client-options --> TestRequest) {
+proto put(|) is export { * }
+multi put(Str $path, *%client-options --> TestRequest) is test-assertion {
     request('PUT', $path, |%client-options)
 }
-multi put(*%client-options --> TestRequest) {
+multi put(*%client-options --> TestRequest) is test-assertion {
     request('PUT', |%client-options)
 }
 


### PR DESCRIPTION
The "is test-assertion" trait only works correctly if it is applied
to candidates of a multi, it does *not* work correctly if only applied
to the proto.