### PR TITLE
Return response promise to caller

### DIFF
--- a/lib/Cro/HTTP/Test.pm6
+++ b/lib/Cro/HTTP/Test.pm6
@@ -159,9 +159,11 @@ sub test(TestRequest:D $request, :$status, :$content-type, :header(:$headers),
     with $*CRO-HTTP-TEST-CONTEXT -> $ctx {
         my $method = $request.method;
         my $path = merge-path($ctx.base-path, $request.path);
+
+        my $resp;
         subtest "$method $path" => {
             my %options := merge-options($ctx.client-options, $request.client-options);
-            my $resp = get-response($ctx.client, $method, $path, %options);
+            $resp = get-response($ctx.client, $method, $path, %options);
             with $status {
                 when Int {
                     is $resp.status, $status, 'Status is acceptable';
@@ -233,6 +235,8 @@ sub test(TestRequest:D $request, :$status, :$content-type, :header(:$headers),
                 ok await($resp.body-blob) ~~ $body-blob, 'Body is acceptable';
             }
         };
+
+        return $resp;
     }
     else {
         die "Should use `test` within a `test-service` block";


### PR DESCRIPTION
When testing REST-like APIs follow-up tests often need the content of the previous request, for example when creating objects.

This allows constructs such as:

```
my $response = test post('/something');
my $response-body = await $response.body;
test get('/something/' ~ $response-body<id>);
```